### PR TITLE
refactor: update workflow to simplify build and lint process

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,20 @@
-name: Build and lint code
+name: Build and lint
 on:
-  pull_request:
-    types: [synchronize, opened]
-env:
-  NODE_ENV: test
+  push:
+    branches:
+      - main
 jobs:
-  build-and-lint-code:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: Borodutch/build-and-lint-code@v1.0.3
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install modules
+        run: yarn
+        shell: bash
+      - name: Build code
+        run: yarn build
+        shell: bash
+      - name: Lint code
+        run: yarn lint
+        shell: bash


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to modify its trigger, rename the workflow, and replace a composite action with explicit steps for better control and customization.

Workflow updates:

* Renamed the workflow from "Build and lint code" to "Build and lint" for brevity. (`.github/workflows/workflow.yml`, [.github/workflows/workflow.ymlL1-R20](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L1-R20))
* Changed the trigger from `pull_request` (types: `synchronize`, `opened`) to `push` on the `main` branch, reflecting a shift in when the workflow runs. (`.github/workflows/workflow.yml`, [.github/workflows/workflow.ymlL1-R20](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L1-R20))
* Replaced the composite action `Borodutch/build-and-lint-code@v1.0.3` with explicit steps for checking out the repository, installing dependencies, building the code, and linting, providing more granular control over the process. (`.github/workflows/workflow.yml`, [.github/workflows/workflow.ymlL1-R20](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L1-R20))