### PR TITLE
fix: update workflow trigger

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,7 @@
 name: Build and lint
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [synchronize, opened]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,7 +16,7 @@ const { CONTRACT_OWNER_PRIVATE_KEY, ETH_RPC, ETHERSCAN_API_KEY } = cleanEnv(
     CONTRACT_OWNER_PRIVATE_KEY: str({
       default: randomPrivateKey,
     }),
-    ETH_RPC: str(),
+    ETH_RPC: str({ default: '' }),
     ETHERSCAN_API_KEY: str({ default: '' }),
   }
 )


### PR DESCRIPTION
This pull request includes changes to the CI workflow and the `hardhat.config.ts` file. The most important changes involve updating the GitHub Actions workflow to trigger on pull request events and modifying the environment variable configuration for Ethereum RPC and Etherscan API keys.

### CI Workflow Updates:
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L3-R4): Updated the workflow to trigger on `pull_request` events (types: `synchronize`, `opened`) instead of `push` events to the `main` branch.

### Environment Variable Configuration:
* [`hardhat.config.ts`](diffhunk://#diff-57cf5378f8cab20b02b279097ba6fad08eb53f747d81770045dda9c5f95effe3L19-R19): Modified the `ETH_RPC` environment variable to include a default value of an empty string, aligning it with the configuration style of `ETHERSCAN_API_KEY`.